### PR TITLE
Check type in check term

### DIFF
--- a/src/lib/check.ml
+++ b/src/lib/check.ml
@@ -99,6 +99,7 @@ and synth ~env ~size ~term =
     let def_val = Nbe.eval def (env_to_sem_env env) in
     synth ~env:(add_term ~term:def_val ~tp:def_tp env) ~size:(size + 1) ~term:body
   | Check (term, tp') ->
+    check_tp ~env ~size ~term:tp';
     let tp = Nbe.eval tp' (env_to_sem_env env) in
     check ~env ~size ~term ~tp;
     tp


### PR DESCRIPTION
This adds a check for the type `tau` in the elaboration of the term `[e at tau]`. Without this, the implementation is normalizing unchecked terms -- the following code snippet causes an infinite loop on `master`:

`let x : U<1> = [U<0> at (fun x -> x x) (fun x -> x x)]`